### PR TITLE
refactor: change typography heading sizes

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-ui",
-  "version": "0.2.3-rc.1",
+  "version": "0.2.3",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "dooboolab",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dooboo-ui",
-  "version": "0.2.2",
+  "version": "0.2.3-rc.1",
   "main": "index.js",
   "types": "index.d.ts",
   "author": "dooboolab",

--- a/main/uis/Typography/Typography.tsx
+++ b/main/uis/Typography/Typography.tsx
@@ -7,8 +7,8 @@ import {isEmptyObject} from '../../utils/utils';
 // Title
 const StyledTitle = styled.Text<{theme: DoobooTheme}>`
   font-family: 'Pretendard-Bold';
-  font-size: 28px;
-  line-height: 39.2px;
+  font-size: 36px;
+  line-height: 50.4px;
   color: ${({theme}) => {
     if (isEmptyObject(theme)) {
       return theme.text.disabled;
@@ -38,36 +38,36 @@ StyledHeading.defaultProps = {style: {includeFontPadding: false}};
 
 export const Heading1 = withTheme(
   styled(StyledHeading)`
+    font-size: 28px;
+    line-height: 39.2px;
+  `,
+);
+
+export const Heading2 = withTheme(
+  styled(StyledHeading)`
     font-size: 26px;
     line-height: 36.4px;
   `,
 );
 
-export const Heading2 = withTheme(
+export const Heading3 = withTheme(
+  styled(StyledHeading)`
+    font-size: 24px;
+    line-height: 33.6px;
+  `,
+);
+
+export const Heading4 = withTheme(
   styled(StyledHeading)`
     font-size: 22px;
     line-height: 30.8px;
   `,
 );
 
-export const Heading3 = withTheme(
-  styled(StyledHeading)`
-    font-size: 18px;
-    line-height: 25.2px;
-  `,
-);
-
-export const Heading4 = withTheme(
-  styled(StyledHeading)`
-    font-size: 16px;
-    line-height: 22.4px;
-  `,
-);
-
 export const Heading5 = withTheme(
   styled(StyledHeading)`
-    font-size: 14px;
-    line-height: 19.6px;
+    font-size: 20px;
+    line-height: 28px;
   `,
 );
 

--- a/main/uis/Typography/TypographyInverted.tsx
+++ b/main/uis/Typography/TypographyInverted.tsx
@@ -7,8 +7,8 @@ import {isEmptyObject} from '../../utils/utils';
 // Title
 const InvertedStyledTitle = styled.Text<{theme: DoobooTheme}>`
   font-family: 'Pretendard-Bold';
-  font-size: 28px;
-  line-height: 39.2px;
+  font-size: 36px;
+  line-height: 50.4px;
   color: ${({theme}) => {
     if (isEmptyObject(theme)) {
       return light.text.contrast;
@@ -38,36 +38,36 @@ InvertedStyledHeading.defaultProps = {style: {includeFontPadding: false}};
 
 export const InvertedHeading1 = withTheme(
   styled(InvertedStyledHeading)`
+    font-size: 28px;
+    line-height: 39.2px;
+  `,
+);
+
+export const InvertedHeading2 = withTheme(
+  styled(InvertedStyledHeading)`
     font-size: 26px;
     line-height: 36.4px;
   `,
 );
 
-export const InvertedHeading2 = withTheme(
+export const InvertedHeading3 = withTheme(
+  styled(InvertedStyledHeading)`
+    font-size: 24px;
+    line-height: 33.6px;
+  `,
+);
+
+export const InvertedHeading4 = withTheme(
   styled(InvertedStyledHeading)`
     font-size: 22px;
     line-height: 30.8px;
   `,
 );
 
-export const InvertedHeading3 = withTheme(
-  styled(InvertedStyledHeading)`
-    font-size: 18px;
-    line-height: 25.2px;
-  `,
-);
-
-export const InvertedHeading4 = withTheme(
-  styled(InvertedStyledHeading)`
-    font-size: 16px;
-    line-height: 22.4px;
-  `,
-);
-
 export const InvertedHeading5 = withTheme(
   styled(InvertedStyledHeading)`
-    font-size: 14px;
-    line-height: 19.6px;
+    font-size: 20px;
+    line-height: 28px;
   `,
 );
 


### PR DESCRIPTION
## Description

Fix `Typography` headings to `h1 / 28`, `h2 / 26`, `h3 / 24`, `h4 / 22`, `h5 / 20`.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide](https://github.com/dooboolab-community/dooboo-ui/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] Run `yarn test:all` and make sure nothing fails.
- [ ] I am willing to follow-up on review comments in a timely manner.
